### PR TITLE
Update float parsing regex and add new test cases

### DIFF
--- a/src/devana/preprocessing/premade/components/parser/argumentsparser.py
+++ b/src/devana/preprocessing/premade/components/parser/argumentsparser.py
@@ -137,7 +137,7 @@ class ArgumentsParser:
         self._name_parser = NameArgumentParser()
         self._parsers = []
         self._parsers.append(ArgumentGenericTypeParser(r"(?P<value>[+-]?\d+)", lambda v, _: int(v)))
-        self._parsers.append(ArgumentGenericTypeParser(r"(?P<value>[+-]?\d+\.?\d*)", lambda v, _: float(v)))
+        self._parsers.append(ArgumentGenericTypeParser(r"(?P<value>[+-]?(?:\.\d+|\d+\.?\d*))", lambda v, _: float(v)))
         self._parsers.append(ListArgumentParser())
         self._parsers.append(ArgumentGenericTypeParser(r'(\"(?P<value>.*)\")', lambda v, _: v))
         self._parsers.append(ArgumentGenericTypeParser( r'(?P<value>true)', lambda v, _: True))

--- a/tests/preprocessing/unit/premade/components/parser/test_argumentsparser.py
+++ b/tests/preprocessing/unit/premade/components/parser/test_argumentsparser.py
@@ -31,15 +31,33 @@ class TestArgumentsParser(unittest.TestCase):
         result = tokenizer.tokenize("7.5")
         self.assertEqual([7.5], result)
 
+        result = tokenizer.tokenize(".5")
+        self.assertEqual([.5], result)
+
+        result = tokenizer.tokenize("7.")
+        self.assertEqual([7.], result)
+
     def test_parse_minus_float(self):
         tokenizer = ArgumentsParser()
         result = tokenizer.tokenize("-7.5")
         self.assertEqual([-7.5], result)
 
+        result = tokenizer.tokenize("-.5")
+        self.assertEqual([-.5], result)
+
+        result = tokenizer.tokenize("-7.")
+        self.assertEqual([-7.], result)
+
     def test_parse_plus_float(self):
         tokenizer = ArgumentsParser()
         result = tokenizer.tokenize("+7.5")
         self.assertEqual([7.5], result)
+
+        result = tokenizer.tokenize("+.5")
+        self.assertEqual([+.5], result)
+
+        result = tokenizer.tokenize("+7.")
+        self.assertEqual([+7.], result)
 
     def test_parse_string(self):
         tokenizer = ArgumentsParser()


### PR DESCRIPTION
Updated the regex in `ArgumentsParser` to handle floats with leading or trailing decimal points. Added new test cases in `TestArgumentsParser` to verify parsing of `.5`, `7.`, `-.5`, `-7.`, `+.5`, and `+7.`.